### PR TITLE
iOS bug fix, fix edge case for gesture events.

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Values:
 * ``2`` means the right-mouse button is depressed.
 * ``4`` means the middle-mouse button is depressed.
 * ``8`` means the x1 (back mouse button) is depressed.
-* ``18`` means the x1 (forward mouse button) is depressed.
+* ``16`` means the x1 (forward mouse button) is depressed.
 * ``32`` means the eraser button on a pen is depressed.
 
 The bitmask of these identifies which buttons are pressed. For example: if both the left and right mouse buttons are depressed, ``event.buttons`` will be 3.

--- a/pointy.gestures.js
+++ b/pointy.gestures.js
@@ -13,6 +13,20 @@
 
 (function ($) {
 
+    // return a cloned copy of a given event that has been slightly modified
+    function copyEvent(originaljQEvent, type, extras) {
+        var event = originaljQEvent; // TODO: this should clone the originaljQEvent object
+
+        event.type = type;
+        event.isPropagationStopped = function () { return false; };
+
+        if (extras) {
+            $.extend(event, extras);
+        }
+
+        return event;
+    }
+
     // also handles sweepleft, sweepright
     $.event.special.sweep = {
         // More than this horizontal displacement, and we will suppress scrolling.
@@ -81,14 +95,8 @@
                     if (start && stop && $.event.special.sweep.isSweep(start, stop, true)) {
                         var dir = start.coords[0] > stop.coords[0] ? "left" : "right";
 
-                        event.type = "sweep";
-                        event.direction = dir;
-
-                        $.event.dispatch.call(thisObject, event);
-
-                        event.type = "sweep" + dir;
-
-                        $.event.dispatch.call(thisObject, event);
+                        $.event.dispatch.call(thisObject, copyEvent(event, "sweep", { direction: dir }));
+                        $.event.dispatch.call(thisObject, copyEvent(event, "sweep" + dir, { direction: dir }));
                     }
 
                     start = stop = undefined;
@@ -175,9 +183,7 @@
 
                     // Trigger a "press" event if the start target is the same as the stop target.
                     if (!isPresshold && origTarget === event.target) {
-                        event.type = "press";
-                        event.isPropagationStopped = function () { return false; };
-                        $.event.dispatch.call(thisObject, event);
+                        $.event.dispatch.call(thisObject, copyEvent(event, "press"));
                     }
 
                     // if this was a "presshold", prevent this "pointerup" event from causing more events
@@ -212,8 +218,7 @@
 
                     // Trigger a "presshold" event if the start target is the same as the stop target.
                     if (origTarget === event.target) {
-                        event.type = "presshold";
-                        $.event.dispatch.call(thisObject, event);
+                        $.event.dispatch.call(thisObject, copyEvent(event, "presshold"));
                     }
                 }, $.event.special.press.pressholdThreshold);
             };

--- a/pointy.gestures.js
+++ b/pointy.gestures.js
@@ -176,6 +176,7 @@
                     // Trigger a "press" event if the start target is the same as the stop target.
                     if (!isPresshold && origTarget === event.target) {
                         event.type = "press";
+                        event.isPropagationStopped = function () { return false; };
                         $.event.dispatch.call(thisObject, event);
                     }
 

--- a/pointy.gestures.js
+++ b/pointy.gestures.js
@@ -19,6 +19,7 @@
 
         event.type = type;
         event.isPropagationStopped = function () { return false; };
+        event.isDefaultPrevented = function () { return false; };
 
         if (extras) {
             $.extend(event, extras);

--- a/pointy.js
+++ b/pointy.js
@@ -396,6 +396,11 @@
 
                 // set the scroll offset which is compared on TouchEnd
                 _startScrollOffset = scrollY();
+
+                // prevent default to prevent the emulated "mousedown" event from being triggered
+                // this also would usually prevent the click event that is triggered by a touch event,
+                // however we trigger a click event on touchend for consistency
+                event.preventDefault();
             },
             mouse: function (event) {
                 // if we just had a touchstart, ignore this MouseDown event, to prevent double firing of PointerDown

--- a/pointy.js
+++ b/pointy.js
@@ -239,8 +239,8 @@
                 event.width = event.height = 0;
             }
 
-            // prevent the follow native click event from occurring, can be used to prevent
-            // clicks on pointerdown or pointerup or from gestures like press and presshold
+            // prevent the following native "click" event from occurring, can be used to prevent
+            // clicks on "pointerdown" or "pointerup" or from gestures like "press" and "presshold"
             event.preventClick = function () {
                 event.isClickPrevented = returnTrue;
                 $(event.target).one("click", returnFalse);
@@ -255,10 +255,10 @@
                 var events = [];
                 var ev, i, j;
 
-                // the problem with this is that on touchend it will remove the
+                // the problem with this is that on "touchend" it will remove the
                 // touch which has ended from the touches list, this means we do
-                // not want to fire pointerup for touches that are still there,
-                // we instead want to send a pointerup with the removed touch's identifier
+                // not want to fire "pointerup" for touches that are still there,
+                // we instead want to send a "pointerup" with the removed touch's identifier
                 if (event.type === "pointerup") {
                     // convert TouchList to a standard array
                     _lastTouches = Array.prototype.slice.call(_lastTouches);
@@ -279,8 +279,9 @@
                         return event;
                     }
                 }
-                // on pointerdown we need to only trigger a new pointerdown for the touch,
-                // and not the touches that were already there
+                // on "pointerdown" we need to only trigger a new "pointerdown" for the new touches (fingers),
+                // and not the touches that were already active. Therefore we filter out all of the touches
+                // based on their identifier that we already knew were active before
                 else if (event.type === "pointerdown") {
                     // convert TouchList to a standard array
                     touches = Array.prototype.slice.call(original.touches);
@@ -377,7 +378,7 @@
     // if browser does not natively handle pointer events,
     // create special custom events to mimic them
     if (!support.pointer) {
-        // stores the scroll-y offest on touchstart and is compared
+        // stores the scroll-y offest on "touchstart" and is compared
         // on touchend to see if we should trigger a click event
         var _startScrollOffset;
 
@@ -391,7 +392,7 @@
                 // set the pointer as currently down to prevent chorded PointerDown events
                 _touching = true;
 
-                // trigger a new PointerDown event
+                // trigger a new "pointerdown" event
                 triggerCustomEvent(this, "pointerdown", event);
 
                 // set the scroll offset which is compared on TouchEnd
@@ -416,9 +417,10 @@
                 var wasAButtonDownAlready = _buttons !== 0;
                 _buttons |= button;
 
-                // do not trigger another PointerDown event if currently down, prevent chorded PointerDown events
+                // do not trigger another "pointerdown" event if a button is currently down,
+                // this prevents chorded "pointerdown" events which is defined in the Pointer Events spec
                 if (wasAButtonDownAlready && _buttons !== button) {
-                    // per the Pointer Events spec, when the active buttons change it fires only a PointerMove event
+                    // per the Pointer Events spec, when the active buttons change it fires only a "pointermove" event
                     triggerCustomEvent(this, "pointermove", event);
                     return;
                 }
@@ -465,7 +467,7 @@
                     return;
                 }
 
-                // indicate that currently release the pointerdown lock
+                // indicate that currently release the "pointerdown" lock
                 _touching = false;
 
                 var jEvent = triggerCustomEvent(this, "pointerup", event);
@@ -513,7 +515,7 @@
 
                 _buttons ^= getStandardizedButtonsProperty(event);
 
-                // we only trigger a PointerUp event if no buttons are down, prevent chorded PointerDown events
+                // we only trigger a "pointerup" event if no buttons are down, prevent chorded PointerDown events
                 if (_buttons === 0) {
                     triggerCustomEvent(this, "pointerup", event);
                 } else {
@@ -521,8 +523,8 @@
                     triggerCustomEvent(this, "pointermove", event);
                 }
 
-                // Mouse Events spec shows that after a MouseUp it fires a MouseMove, which will trigger
-                // the PointerMove needed to follow the Pointer Events spec which describes the same thing
+                // Mouse Events spec shows that after a "mouseup" it fires a "mousemove", which will trigger
+                // the "pointermove" needed to follow the Pointer Events spec which describes the same thing
             },
             add: $.event.delegateSpecial(function (handleObj) {
                 // bind to touch events, some devices (chromebook) can send both touch and mouse events

--- a/pointy.js
+++ b/pointy.js
@@ -403,7 +403,7 @@
             },
             mouse: function (event) {
                 // if we just had a "touchstart", ignore this "mousedown" event, to prevent double firing of "pointerdown"
-                if (typeof _touching === 'number') {
+                if (typeof _touching === "number") {
                     return;
                 }
 
@@ -586,7 +586,7 @@
                 // because we cannot call preventDefault on the "touchmove" without preventing
                 // scrolling on most things, we do this check to ensure we don't double fire
                 // move events.
-                if (typeof _touching === 'number') {
+                if (typeof _touching === "number") {
                     return;
                 }
 

--- a/pointy.js
+++ b/pointy.js
@@ -225,7 +225,7 @@
 
             // if we have the bitmask for the depressed buttons from the mouse events polyfill, use it to mimic buttons for
             // browsers that do not support the HTML DOM LEVEL 3 events spec
-            if (event.type === "pointermove" && _touching === null && _buttons !== event.buttons) {
+            if (event.type !== "pointerdown" && event.pointerType === "mouse" && _touching === null && _buttons !== event.buttons) {
                 event.buttons = _buttons;
             }
 
@@ -493,7 +493,6 @@
                     return;
                 }
 
-
                 // on "touchend", calling prevent default prevents the "mouseup" and "click" event
                 // however on native "mouseup" events preventing default does not cancel the "click" event
                 // as per the pointer event spec on "pointerup" preventing default should not cancel the "click" event
@@ -544,6 +543,7 @@
                     return;
                 }
 
+                // on mouseup, the event.button will be the button that was just released
                 _buttons ^= getStandardizedButtonsProperty(event);
 
                 // we only trigger a "pointerup" event if no buttons are down, prevent chorded PointerDown events

--- a/pointy.js
+++ b/pointy.js
@@ -624,6 +624,12 @@
             }
         }, function (pointerEventType, natives) {
             function onTouch(event) {
+                // pointercancel, reset everything
+                if (event.type === "touchcancel") {
+                    _touching = null;
+                    _buttons = 0;
+                }
+
                 triggerCustomEvent(this, pointerEventType, event);
             }
 

--- a/test/pointy.unittests.js
+++ b/test/pointy.unittests.js
@@ -19,7 +19,7 @@ describe('pointy.js', function () {
         // trigger native event, should trigger the pointer event and call workIt
         el.triggerNative(nativeEvent);
 
-        // confirm workIt was called
+        // confirm flagIfCalled was called
         chai.assert.isTrue(called);
 
         if (teardown) {

--- a/test/pointy.unittests.js
+++ b/test/pointy.unittests.js
@@ -1,24 +1,33 @@
 describe('pointy.js', function () {
     var el = $('#test');
 
-    var isCalled = function (pointerEvent, nativeEvent) {
+    var isCalled = function (pointerEvent, nativeEvent, nativeEventProps, cb) {
         var called = false;
         var teardown = true;
 
-        function flagIfCalled() {
+        if ($.isFunction(nativeEventProps)) {
+            cb = nativeEventProps;
+            nativeEventProps = null;
+        }
+
+        function flagIfCalled(event) {
             if (called) {
                 chai.assert.fail('should never call this flag write');
                 teardown = false;
             }
 
             called = true;
+
+            if (cb) {
+                cb(event);
+            }
         }
 
         // bind to the pointer event
         el.on(pointerEvent, flagIfCalled);
 
         // trigger native event, should trigger the pointer event and call workIt
-        el.triggerNative(nativeEvent);
+        el.triggerNative(nativeEvent, nativeEventProps);
 
         // confirm flagIfCalled was called
         chai.assert.isTrue(called);
@@ -35,41 +44,67 @@ describe('pointy.js', function () {
 
     describe('touch transformation', function () {
         it('should trigger a pointerdown when a touchstart is triggered', function () {
-            isCalled('pointerdown', 'touchstart');
+            isCalled('pointerdown', 'touchstart', function (event) {
+                chai.assert.equal(event.pointerType, 'touch');
+                chai.assert.equal(event.buttons, 1);
+            });
         });
 
         it('should trigger a pointermove when a touchmove is triggered', function () {
-            isCalled('pointermove', 'touchmove');
+            isCalled('pointermove', 'touchmove', function (event) {
+                chai.assert.equal(event.pointerType, 'touch');
+                chai.assert.equal(event.buttons, 1);
+            });
         });
 
         it('should trigger a pointerup when a touchend is triggered', function () {
-            isCalled('pointerup', 'touchend');
+            isCalled('pointerup', 'touchend', function (event) {
+                chai.assert.equal(event.pointerType, 'touch');
+                chai.assert.equal(event.buttons, 0);
+            });
         });
 
         it('should trigger a pointercancel when a touchcancel is triggered', function () {
-            isCalled('pointercancel', 'touchcancel');
+            isCalled('pointercancel', 'touchcancel', function (event) {
+                chai.assert.equal(event.pointerType, 'touch');
+            });
         });
     });
 
     describe('mouse transformation', function () {
         it('should trigger a pointerdown when a mousedown is triggered', function () {
-            isCalled('pointerdown', 'mousedown');
+            isCalled('pointerdown', 'mousedown', { button: 1 }, function (event) {
+                chai.assert.equal(event.pointerType, 'mouse');
+                chai.assert.equal(event.buttons, 1);
+            });
         });
 
         it('should trigger a pointermove when a mousemove is triggered', function () {
-            isCalled('pointermove', 'mousemove');
+            isCalled('pointermove', 'mousemove', function (event) {
+                chai.assert.equal(event.pointerType, 'mouse');
+                chai.assert.equal(event.buttons, 1);
+            });
         });
 
         it('should trigger a pointerover when a mouseover is triggered', function () {
-            isCalled('pointerover', 'mouseover');
+            isCalled('pointerover', 'mouseover', function (event) {
+                chai.assert.equal(event.pointerType, 'mouse');
+                chai.assert.equal(event.buttons, 1);
+            });
         });
 
         it('should trigger a pointerout when a mouseout is triggered', function () {
-            isCalled('pointerout', 'mouseout');
+            isCalled('pointerout', 'mouseout', function (event) {
+                chai.assert.equal(event.pointerType, 'mouse');
+                chai.assert.equal(event.buttons, 1);
+            });
         });
 
         it('should trigger a pointerup when a mouseup is triggered', function () {
-            isCalled('pointerup', 'mouseup');
+            isCalled('pointerup', 'mouseup', { button: 1 }, function (event) {
+                chai.assert.equal(event.pointerType, 'mouse');
+                chai.assert.equal(event.buttons, 0);
+            });
         });
     });
 

--- a/test/pointy.unittests.js
+++ b/test/pointy.unittests.js
@@ -1,8 +1,9 @@
 describe('pointy.js', function () {
     var el = $('#test');
 
-    var isCalled = function (pointerEvent, nativeEvent, teardown) {
+    var isCalled = function (pointerEvent, nativeEvent) {
         var called = false;
+        var teardown = true;
 
         function flagIfCalled() {
             if (called) {
@@ -34,33 +35,33 @@ describe('pointy.js', function () {
 
     describe('touch transformation', function () {
         it('should trigger a pointerdown when a touchstart is triggered', function () {
-            isCalled('pointerdown', 'touchstart', true);
+            isCalled('pointerdown', 'touchstart');
         });
 
         it('should trigger a pointermove when a touchmove is triggered', function () {
-            isCalled('pointermove', 'touchmove', true);
+            isCalled('pointermove', 'touchmove');
         });
 
         it('should trigger a pointerup when a touchend is triggered', function () {
-            isCalled('pointerup', 'touchend', true);
+            isCalled('pointerup', 'touchend');
         });
 
         it('should trigger a pointercancel when a touchcancel is triggered', function () {
-            isCalled('pointercancel', 'touchcancel', true);
+            isCalled('pointercancel', 'touchcancel');
         });
     });
 
     describe('mouse transformation', function () {
         it('should trigger a pointerdown when a mousedown is triggered', function () {
-            isCalled('pointerdown', 'mousedown', true);
+            isCalled('pointerdown', 'mousedown');
         });
 
         it('should trigger a pointermove when a mousemove is triggered', function () {
-            isCalled('pointermove', 'mousemove', true);
+            isCalled('pointermove', 'mousemove');
         });
 
         it('should trigger a pointerover when a mouseover is triggered', function () {
-            isCalled('pointerover', 'mouseover', true);
+            isCalled('pointerover', 'mouseover');
         });
 
         it('should trigger a pointerout when a mouseout is triggered', function () {
@@ -68,7 +69,7 @@ describe('pointy.js', function () {
         });
 
         it('should trigger a pointerup when a mouseup is triggered', function () {
-            isCalled('pointerup', 'mouseup', true);
+            isCalled('pointerup', 'mouseup');
         });
     });
 


### PR DESCRIPTION
iOS fix: on touch devices (TouchEvents), a slow tap would result in the emulated `mousedown`, `mouseup` and `click` event still. To prevent this, _we have to_ call `event.preventDefault()` on `touchstart`. We used to do this to fix this problem, however we removed that because it resulted in the native `click` event from always being prevented. We are able to do this now however because we now always ensure a `click` event is triggered from the `pointerup` event. We also ensure that whenever you listen only to a `pointerdown` event we also bind a noop `pointerup` event to simply ensure that we keep proper track of active buttons.

Additional fix to resolve edge case. If you call `event.stopPropagation()` on a `pointerup` event it would result in the following `press` event from not firing. Other similar edge cases exist, and we must clone the original event before triggering `press`, `presshold` or `sweep` events. I've created an outline for this but the complete issue is not resolved, however the propagation issue is. Additionally I've done the same thing to the `event.preventDefault()` method by resetting it as well before triggering the pointy.gesture event.
